### PR TITLE
MF - Expo - Onboarding Helper

### DIFF
--- a/app/onboarding-helper.tsx
+++ b/app/onboarding-helper.tsx
@@ -1,0 +1,11 @@
+
+import { OnboardingHelperView, ThemeProvider } from 'masterfabric-expo-core';
+import React from 'react';
+
+export default function OnboardingHelperScreen() {
+  return (
+    <ThemeProvider>
+      <OnboardingHelperView />
+    </ThemeProvider>
+  );
+}

--- a/packages/masterfabric-expo-core/src/components/index.ts
+++ b/packages/masterfabric-expo-core/src/components/index.ts
@@ -1,0 +1,7 @@
+
+export * from './MasterView';
+export * from './ScreenHeader';
+export * from './ThemedText';
+export * from './ThemedView';
+export * from './battery';
+export * from './onboarding-helper';

--- a/packages/masterfabric-expo-core/src/components/onboarding-helper/OnboardingHelperView.tsx
+++ b/packages/masterfabric-expo-core/src/components/onboarding-helper/OnboardingHelperView.tsx
@@ -1,0 +1,70 @@
+
+import React from 'react';
+import { ScrollView, RefreshControl, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getThemeColors } from '../../constants/Colors';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ScreenHeader } from '../ScreenHeader';
+import { ThemedText } from '../ThemedText';
+import { useOnboardingHelperViewModel } from '../../hooks/useOnboardingHelperViewModel';
+import { OnboardingStatusCard } from './OnboardingStatusCard';
+import { screenStyles } from '../../styles/screen.styles'; // A new generic screen style
+
+export function OnboardingHelperView() {
+  const { currentTheme } = useTheme();
+  const isDark = currentTheme === 'dark';
+  const colors = getThemeColors(isDark);
+
+  const {
+    hasCompleted,
+    isLoading,
+    error,
+    statusText,
+    statusDescription,
+    handleComplete,
+    handleReset,
+    handleRefresh,
+  } = useOnboardingHelperViewModel();
+
+  return (
+    <SafeAreaView
+      style={[screenStyles.container, { backgroundColor: colors.background }]}
+      edges={['top']}
+    >
+      <ScreenHeader
+        title="Onboarding Helper"
+        subtitle="Manage and test the onboarding flow"
+      />
+
+      <ScrollView
+        style={screenStyles.scrollView}
+        contentContainerStyle={screenStyles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={isLoading}
+            onRefresh={handleRefresh}
+            tintColor={colors.primary}
+          />
+        }
+      >
+        {error && (
+          <ThemedText style={{ color: colors.errorColor, padding: 16 }}>
+            {error}
+          </ThemedText>
+        )}
+
+        <View style={screenStyles.cardContainer}>
+          <OnboardingStatusCard
+            hasCompleted={hasCompleted}
+            isLoading={isLoading}
+            statusText={statusText}
+            statusDescription={statusDescription}
+            onComplete={handleComplete}
+            onReset={handleReset}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/packages/masterfabric-expo-core/src/components/onboarding-helper/OnboardingStatusCard.tsx
+++ b/packages/masterfabric-expo-core/src/components/onboarding-helper/OnboardingStatusCard.tsx
@@ -1,0 +1,92 @@
+
+import React from 'react';
+import { View, Button, ActivityIndicator } from 'react-native';
+import { getThemeColors } from '../../constants/Colors';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ThemedText } from '../ThemedText';
+import { ThemedView } from '../ThemedView';
+import { cardStyles } from '../../styles/card.styles'; // A new generic card style
+
+interface OnboardingStatusCardProps {
+  statusText: string;
+  statusDescription: string;
+  isLoading: boolean;
+  hasCompleted: boolean;
+  onComplete: () => void;
+  onReset: () => void;
+}
+
+export function OnboardingStatusCard({
+  statusText,
+  statusDescription,
+  isLoading,
+  hasCompleted,
+  onComplete,
+  onReset,
+}: OnboardingStatusCardProps) {
+  const { currentTheme } = useTheme();
+  const isDark = currentTheme === 'dark';
+  const colors = getThemeColors(isDark);
+
+  return (
+    <ThemedView
+      style={[
+        cardStyles.container,
+        {
+          backgroundColor: colors.surfaceBackground,
+          borderColor: colors.surfaceBorder + '30',
+        },
+      ]}
+    >
+      <View style={cardStyles.header}>
+        <ThemedText
+          type="subtitle"
+          style={[cardStyles.title, { color: colors.sectionTitle }]}
+        >
+          Onboarding Status
+        </ThemedText>
+        {isLoading && <ActivityIndicator size="small" color={colors.primary} />}
+      </View>
+
+      <View style={cardStyles.statusContainer}>
+        <View
+          style={[
+            cardStyles.statusIndicator,
+            {
+              backgroundColor: hasCompleted
+                ? colors.successColor
+                : colors.warningColor,
+            },
+          ]}
+        />
+        <ThemedText
+          style={[cardStyles.statusText, { color: colors.text }]}
+        >
+          {statusText}
+        </ThemedText>
+      </View>
+
+      <ThemedText
+        style={[cardStyles.description, { color: colors.text }]}
+      >
+        {statusDescription}
+      </ThemedText>
+
+      <View style={cardStyles.buttonContainer}>
+        <Button
+          title="Mark as Completed"
+          onPress={onComplete}
+          disabled={isLoading || hasCompleted}
+          color={colors.primary}
+        />
+        <View style={{ height: 8 }} />
+        <Button
+          title="Reset Status"
+          onPress={onReset}
+          disabled={isLoading || !hasCompleted}
+          color={colors.errorColor}
+        />
+      </View>
+    </ThemedView>
+  );
+}

--- a/packages/masterfabric-expo-core/src/components/onboarding-helper/index.ts
+++ b/packages/masterfabric-expo-core/src/components/onboarding-helper/index.ts
@@ -1,0 +1,3 @@
+
+export * from './OnboardingHelperView';
+export * from './OnboardingStatusCard';

--- a/packages/masterfabric-expo-core/src/helpers/index.ts
+++ b/packages/masterfabric-expo-core/src/helpers/index.ts
@@ -26,6 +26,9 @@ export * from './toast_helper';
 // Rich Text Helper
 export * from './rich_text_helper';
 
+// Onboarding Helper
+export * from './onboarding_helper';
+
 // Re-export types with different names to avoid conflicts
 export type { DeviceInfo as DeviceInfoHelper, DeviceInfoOptions } from './device-info';
 

--- a/packages/masterfabric-expo-core/src/helpers/onboarding_helper.ts
+++ b/packages/masterfabric-expo-core/src/helpers/onboarding_helper.ts
@@ -1,0 +1,54 @@
+
+import { storage } from '../utils/storage';
+
+const ONBOARDING_STORAGE_KEY = '@masterfabric_onboarding_completed';
+
+/**
+ * Returns the storage key used for onboarding completion status.
+ * @returns The storage key.
+ */
+export function getOnboardingStorageKey(): string {
+  return ONBOARDING_STORAGE_KEY;
+}
+
+/**
+ * Checks if the user has completed or skipped the onboarding process.
+ * @returns A promise that resolves to true if onboarding is completed/skipped, false otherwise.
+ */
+export async function hasCompletedOnboarding(): Promise<boolean> {
+  const completed = await storage.get<boolean>(ONBOARDING_STORAGE_KEY);
+  return completed === true;
+}
+
+/**
+ * Marks the onboarding process as completed.
+ * @returns A promise that resolves when the state is saved.
+ */
+export async function markOnboardingCompleted(): Promise<void> {
+  await storage.set(ONBOARDING_STORAGE_KEY, true);
+}
+
+/**
+ * Marks the onboarding process as skipped. This has the same effect as completing it.
+ * @returns A promise that resolves when the state is saved.
+ */
+export async function markOnboardingSkipped(): Promise<void> {
+  await storage.set(ONBOARDING_STORAGE_KEY, true);
+}
+
+/**
+ * Resets the onboarding completion state. Useful for development and testing.
+ * @returns A promise that resolves when the state is removed.
+ */
+export async function resetOnboarding(): Promise<void> {
+  await storage.remove(ONBOARDING_STORAGE_KEY);
+}
+
+/**
+ * Determines if the onboarding screen should be shown.
+ * @returns A promise that resolves to true if onboarding should be shown, false otherwise.
+ */
+export async function shouldShowOnboarding(): Promise<boolean> {
+  const hasCompleted = await hasCompletedOnboarding();
+  return !hasCompleted;
+}

--- a/packages/masterfabric-expo-core/src/hooks/index.ts
+++ b/packages/masterfabric-expo-core/src/hooks/index.ts
@@ -1,0 +1,4 @@
+
+export * from './useBatteryHelper';
+export * from './useMasterView';
+export * from './useOnboardingHelperViewModel';

--- a/packages/masterfabric-expo-core/src/hooks/useOnboardingHelperViewModel.ts
+++ b/packages/masterfabric-expo-core/src/hooks/useOnboardingHelperViewModel.ts
@@ -1,0 +1,56 @@
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { useOnboardingHelperStore } from '../stores/onboardingStore';
+
+export const useOnboardingHelperViewModel = () => {
+  const {
+    hasCompleted,
+    isLoading,
+    error,
+    loadStatus,
+    completeOnboarding,
+    resetOnboarding,
+  } = useOnboardingHelperStore();
+
+  // Initial load of the status
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  // Memoized status text
+  const statusText = useMemo(
+    () => hasCompleted ? 'Completed' : 'Not Completed',
+    [hasCompleted]
+  );
+
+  const statusDescription = useMemo(
+    () => hasCompleted
+      ? 'The app will skip the onboarding flow on the next launch.'
+      : 'The onboarding flow will be shown on the next app launch.',
+    [hasCompleted]
+  );
+
+  // Handlers for the view to call
+  const handleComplete = useCallback(async () => {
+    await completeOnboarding();
+  }, [completeOnboarding]);
+
+  const handleReset = useCallback(async () => {
+    await resetOnboarding();
+  }, [resetOnboarding]);
+
+  const handleRefresh = useCallback(async () => {
+    await loadStatus();
+  }, [loadStatus]);
+
+  return {
+    hasCompleted,
+    isLoading,
+    error,
+    statusText,
+    statusDescription,
+    handleComplete,
+    handleReset,
+    handleRefresh,
+  };
+};

--- a/packages/masterfabric-expo-core/src/index.ts
+++ b/packages/masterfabric-expo-core/src/index.ts
@@ -56,3 +56,8 @@ export * from './stores/batteryStore';
 export * from './helpers/batteryHelper';
 export * from './types/battery';
 
+// Onboarding Helper
+export * from './components/onboarding-helper/OnboardingHelperView';
+export * from './hooks/useOnboardingHelperViewModel';
+export * from './stores/onboardingStore';
+

--- a/packages/masterfabric-expo-core/src/stores/index.ts
+++ b/packages/masterfabric-expo-core/src/stores/index.ts
@@ -1,0 +1,4 @@
+
+export * from './batteryStore';
+export * from './MasterViewStore';
+export * from './onboardingStore';

--- a/packages/masterfabric-expo-core/src/stores/onboardingStore.ts
+++ b/packages/masterfabric-expo-core/src/stores/onboardingStore.ts
@@ -1,0 +1,50 @@
+
+import { create } from 'zustand';
+import { hasCompletedOnboarding, markOnboardingCompleted, resetOnboarding } from '../helpers/onboarding_helper';
+
+interface OnboardingHelperState {
+  hasCompleted: boolean;
+  isLoading: boolean;
+  error: string | null;
+  loadStatus: () => Promise<void>;
+  completeOnboarding: () => Promise<void>;
+  resetOnboarding: () => Promise<void>;
+  setLoading: (loading: boolean) => void;
+}
+
+export const useOnboardingHelperStore = create<OnboardingHelperState>((set) => ({
+  hasCompleted: false,
+  isLoading: false,
+  error: null,
+  setLoading: (loading) => set({ isLoading: loading }),
+  loadStatus: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const status = await hasCompletedOnboarding();
+      set({ hasCompleted: status, isLoading: false });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : 'Failed to load onboarding status.';
+      set({ error, isLoading: false });
+    }
+  },
+  completeOnboarding: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      await markOnboardingCompleted();
+      set({ hasCompleted: true, isLoading: false });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : 'Failed to mark onboarding as completed.';
+      set({ error, isLoading: false });
+    }
+  },
+  resetOnboarding: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      await resetOnboarding();
+      set({ hasCompleted: false, isLoading: false });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : 'Failed to reset onboarding status.';
+      set({ error, isLoading: false });
+    }
+  },
+}));

--- a/packages/masterfabric-expo-core/src/styles/card.styles.ts
+++ b/packages/masterfabric-expo-core/src/styles/card.styles.ts
@@ -1,0 +1,45 @@
+
+import { StyleSheet } from 'react-native';
+
+export const cardStyles = StyleSheet.create({
+  container: {
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  statusContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  statusIndicator: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  statusText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  description: {
+    fontSize: 12,
+    opacity: 0.7,
+    marginBottom: 16,
+    lineHeight: 18,
+  },
+  buttonContainer: {
+    marginTop: 8,
+  },
+});

--- a/packages/masterfabric-expo-core/src/styles/index.ts
+++ b/packages/masterfabric-expo-core/src/styles/index.ts
@@ -2,3 +2,5 @@ export * from './BatteryHelperView.styles';
 export * from './BatteryStatusCard.styles';
 export * from './DeviceInfoCard.styles';
 export * from './LowPowerModeCard.styles';
+export * from './card.styles';
+export * from './screen.styles';

--- a/packages/masterfabric-expo-core/src/styles/screen.styles.ts
+++ b/packages/masterfabric-expo-core/src/styles/screen.styles.ts
@@ -1,0 +1,18 @@
+
+import { StyleSheet } from 'react-native';
+
+export const screenStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 100,
+  },
+  cardContainer: {
+    marginBottom: 16,
+  },
+});

--- a/src/screens/helpers/utils/index.ts
+++ b/src/screens/helpers/utils/index.ts
@@ -43,6 +43,8 @@ export const getHelperIcon = (helperId: string): string => {
       return 'document-text-outline';
     case 'typography-helper':
       return 'text-outline';
+    case 'onboarding-helper':
+      return 'school-outline';
     default:
       return 'help-outline';
   }
@@ -79,6 +81,8 @@ export const getHelperColor = (helperId: string): string => {
       return '#AF52DE'; // Purple for rich text helpers
     case 'typography-helper':
       return '#007AFF'; // Blue for typography helpers
+    case 'onboarding-helper':
+      return '#FF3B30'; // Red for onboarding helper
     default:
       return '#8E8E93';
   }
@@ -174,6 +178,16 @@ export const createDefaultHelperItems = (): HelperItem[] => [
     route: '/typography-helper',
     available: true,
     category: 'text-helpers'
+  },
+  {
+    id: 'onboarding-helper',
+    name: 'Onboarding Flow Manager',
+    description: 'Tool for managing and testing the app\'s initial onboarding experience.',
+    icon: 'school-outline',
+    color: '#FF3B30',
+    route: '/onboarding-helper',
+    available: true,
+    category: 'dev-helpers'
   }
 ];
 

--- a/src/screens/onboarding/store/onboarding-store.ts
+++ b/src/screens/onboarding/store/onboarding-store.ts
@@ -1,6 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createOnboardingSteps } from '../utils';
+import { 
+  markOnboardingCompleted, 
+  resetOnboarding as resetOnboardingHelper,
+  hasCompletedOnboarding 
+} from 'masterfabric-expo-core';
 
 interface OnboardingState {
   currentStepIndex: number;
@@ -16,8 +20,6 @@ interface OnboardingState {
   loadOnboardingStatus: () => Promise<void>;
   setHasSeenOnboarding: (hasSeen: boolean) => void;
 }
-
-const ONBOARDING_STORAGE_KEY = '@masterfabric_onboarding_completed';
 
 const initialState = {
   currentStepIndex: 0,
@@ -57,7 +59,7 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
     
   completeOnboarding: async () => {
     try {
-      await AsyncStorage.setItem(ONBOARDING_STORAGE_KEY, 'true');
+      await markOnboardingCompleted();
       set({ isCompleted: true, hasSeenOnboarding: true });
     } catch (error) {
       console.error('Error saving onboarding completion:', error);
@@ -66,7 +68,7 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
     
   resetOnboarding: async () => {
     try {
-      await AsyncStorage.removeItem(ONBOARDING_STORAGE_KEY);
+      await resetOnboardingHelper();
       set(initialState);
     } catch (error) {
       console.error('Error resetting onboarding:', error);
@@ -75,10 +77,10 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
     
   loadOnboardingStatus: async () => {
     try {
-      const hasCompleted = await AsyncStorage.getItem(ONBOARDING_STORAGE_KEY);
+      const hasCompleted = await hasCompletedOnboarding();
       set({ 
-        hasSeenOnboarding: hasCompleted === 'true',
-        isCompleted: hasCompleted === 'true'
+        hasSeenOnboarding: hasCompleted,
+        isCompleted: hasCompleted
       });
     } catch (error) {
       console.error('Error loading onboarding status:', error);

--- a/src/screens/splash/hooks/use-splash-view-model.ts
+++ b/src/screens/splash/hooks/use-splash-view-model.ts
@@ -2,9 +2,9 @@ import { navigationUtils } from '@/src/navigation/utils';
 import { t } from '@/src/shared/i18n';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { useOnboardingStore } from '../../onboarding/store/onboarding-store';
 import { useSplashStore } from '../store/splash-store';
-import { createSplashSteps, getProgressPercentage, shouldShowOnboarding } from '../utils';
+import { createSplashSteps, getProgressPercentage } from '../utils';
+import { shouldShowOnboarding } from 'masterfabric-expo-core';
 
 export function useSplashViewModel() {
   const [progress, setProgress] = useState(0);
@@ -18,25 +18,13 @@ export function useSplashViewModel() {
     setCurrentStep,
     addCompletedStep 
   } = useSplashStore();
-  const { hasSeenOnboarding, isCompleted, loadOnboardingStatus } = useOnboardingStore();
 
   useEffect(() => {
     initializeApp();
   }, []);
 
-  // Listen for onboarding completion
-  useEffect(() => {
-    if (isCompleted && !isLoading) {
-      console.log('🎉 Onboarding completed, navigating to home tabs');
-      navigationUtils.replace('(tabs)');
-    }
-  }, [isCompleted, isLoading]);
-
   const initializeApp = async () => {
     setLoading(true);
-    
-    // Load onboarding status first
-    await loadOnboardingStatus();
     
     const steps = createSplashSteps();
     const completed: string[] = [];
@@ -67,14 +55,11 @@ export function useSplashViewModel() {
     }, 500);
   };
 
-  const navigateToNextScreen = () => {
+  const navigateToNextScreen = async () => {
     console.log('🧿 Splash screen completed, checking onboarding status');
-    console.log('hasSeenOnboarding:', hasSeenOnboarding);
-    console.log('isCompleted:', isCompleted);
     
     try {
-      // Use utility function to determine navigation
-      if (shouldShowOnboarding(hasSeenOnboarding, isCompleted)) {
+      if (await shouldShowOnboarding()) {
         console.log('First time user - navigating to onboarding');
         router.push('/onboarding');
       } else {

--- a/src/screens/splash/utils/index.ts
+++ b/src/screens/splash/utils/index.ts
@@ -46,11 +46,6 @@ export const getStepById = (steps: SplashStep[], id: string): SplashStep | undef
   return steps.find(step => step.id === id);
 };
 
-// Navigation utilities
-export const shouldShowOnboarding = (hasSeenOnboarding: boolean, isCompleted: boolean): boolean => {
-  return !hasSeenOnboarding && !isCompleted;
-};
-
 // Loading message utilities
 export const getLoadingMessage = (stepId: string): string => {
   switch (stepId) {

--- a/src/shared/i18n/translations/en.json
+++ b/src/shared/i18n/translations/en.json
@@ -1005,6 +1005,10 @@
       "deviceInfoUnavailable": "Device information is not available",
       "unknown": "Unknown",
       "errorRetry": "Error loading battery info. Tap to retry"
+    },
+    "onboardingHelper": {
+      "title": "Onboarding Helper",
+      "description": "Tool for managing and testing the app's initial onboarding experience."
     }
   },
   "documentation": {

--- a/src/shared/i18n/translations/tr.json
+++ b/src/shared/i18n/translations/tr.json
@@ -942,6 +942,10 @@
       "deviceInfoUnavailable": "Cihaz bilgileri mevcut değil",
       "unknown": "Bilinmiyor",
       "errorRetry": "Pil bilgileri yüklenirken hata oluştu. Tekrar denemek için dokunun"
+    },
+    "onboardingHelper": {
+      "title": "Onboarding Yardımcısı",
+      "description": "Uygulamanın başlangıçtaki tanıtım deneyimini yönetme ve test etme aracı."
     }
   },
   "documentation": {


### PR DESCRIPTION
## 📋 PR Description

This PR introduces a centralized **Onboarding Helper** to manage the persistence of the onboarding flow's completion status. It resolves scattered logic and potential inconsistencies by providing a single source of truth.

Additionally, it adds a new developer-facing screen to the "Helpers" section, allowing developers to easily view, manage, and test the onboarding status.

This entire implementation is based on **Issue #20**.

### Key Architectural Changes

1.  **Centralized Logic (`packages/masterfabric-expo-core/src/helpers/onboarding_helper.ts`)**
    *   **Why:** Previously, the logic for checking and setting the onboarding status was duplicated in the splash screen and the onboarding store, with direct calls to `AsyncStorage`.
    *   **What:** A new `onboarding_helper.ts` module was created. It encapsulates all `AsyncStorage` interactions and exports a clean, asynchronous API (`hasCompletedOnboarding`, `markOnboardingCompleted`, `resetOnboarding`). This aligns with our architecture of keeping core logic centralized and reusable.

2.  **Refactored Application Code**
    *   **Why:** To eliminate duplicated logic and make the application code cleaner and more maintainable.
    *   **What:** The splash screen's navigation logic and the onboarding Zustand store have been refactored to use the new `onboarding_helper`. They are no longer aware of the underlying persistence mechanism.

3.  **New Developer Tool (`Onboarding Helper` Screen)**
    *   **Why:** To provide developers with a simple UI to test the onboarding flow without needing to manually clear app data or edit code.
    *   **What:** A new screen was added, strictly following the existing architectural pattern of other helper screens (e.g., `Battery Helper`). It uses a `ViewModel (Hook)` -> `Store` -> `View` pattern for consistency and scalability.

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary (via this PR description).
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1.  Launch the app and navigate to the **Helpers** screen from the "Quick Actions" section on the Home page.
2.  Verify that a new card, **"Onboarding Helper"**, appears in the list. Tap on it.
3.  On the "Onboarding Helper" screen, confirm that the initial status is **"Not Completed"**.
4.  Tap the **"Mark as Completed"** button. The status should update to **"Completed"**, and the buttons should update their disabled state accordingly.
5.  Fully close and restart the application.
6.  **Verify** that the app navigates directly from the splash screen to the main tabs, **skipping** the onboarding flow.
7.  Navigate back to the "Onboarding Helper" screen and tap **"Reset Status"**.
8.  Confirm the status changes back to **"Not Completed"**.
9.  Fully close and restart the application one more time.
10. **Verify** that the onboarding flow is now shown after the splash screen.

---

## 🔗 Related Links

-   **Issue:** #20
-   **Documentation:** This PR description serves as the primary documentation for this feature.

### Core Package Usecase (Mini-Documentation)

For a developer using the `masterfabric-expo-core` package, here is how to use the new features:

#### 1. Checking if Onboarding Should Be Shown

In your application's startup or navigation logic (e.g., after a splash screen), you can use the helper to decide where to navigate.

```typescript
import { shouldShowOnboarding } from 'masterfabric-expo-core';
import { router } from 'expo-router';

async function navigateAfterSplash() {
  if (await shouldShowOnboarding()) {
    router.replace('/onboarding');
  } else {
    router.replace('/(tabs)/home');
  }
}
```

#### 2. Marking Onboarding as Completed or Skipped

When the user finishes the onboarding flow or presses a "Skip" button, call the appropriate function to persist this state.

```typescript
import { markOnboardingCompleted, markOnboardingSkipped } from 'masterfabric-expo-core';
import { router } from 'expo-router';

// When user presses "Get Started" on the final onboarding slide
async function onFinishOnboarding() {
  await markOnboardingCompleted();
  router.replace('/(tabs)/home');
}

// When user presses "Skip"
async function onSkipOnboarding() {
  await markOnboardingSkipped(); // This has the same effect as completing
  router.replace('/(tabs)/home');
}
```

#### 3. Adding the Developer Screen (Optional)

If you want to include the helper screen in your app for testing:

```typescript
// In your navigation setup (e.g., a developer menu)

import { OnboardingHelperView, ThemeProvider } from 'masterfabric-expo-core';

// This is a basic screen component that renders the helper view
function OnboardingHelperScreen() {
  return (
    <ThemeProvider>
      <OnboardingHelperView />
    </ThemeProvider>
  );
}

```

---

### 📷 Screenshots (Optional)

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/318efe6e-3f85-4577-9bb7-33632a272c7f" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a9bc7cf3-352c-4f9e-bf6e-7a283bca065e" />